### PR TITLE
Using delete to remove the versionedModel._id in the collection strategy

### DIFF
--- a/lib/strategies/collection.js
+++ b/lib/strategies/collection.js
@@ -33,7 +33,7 @@ module.exports = function(schema, options) {
         var versionedModel = new schema.statics.VersionedModel(this);
         versionedModel.refVersion = this._doc.__v;   // Saves current document version
         versionedModel.refId = this._id;        // Sets origins document id as a reference
-        versionedModel._id = undefined;
+        delete versionedModel._id;
 
         versionedModel.save(function(err) {
             if (options.logError && err) {


### PR DESCRIPTION
I was getting an error when trying to save a new version because the `_id` field existed on the model, but was undefined.
