### PR TITLE
refVersion is out of sync by 1 for each version. This happens becuase th...

### DIFF
--- a/lib/strategies/array.js
+++ b/lib/strategies/array.js
@@ -87,7 +87,7 @@ module.exports = function(schema, options) {
                 }
             }
 
-            versionCopy.refVersion = self._doc.__v || 0;
+            versionCopy.refVersion = self._doc.__v + 1 || 0;
             versionCopy._id = undefined;
 
             versionedModel.versions.push(versionCopy);


### PR DESCRIPTION
refVersion is out of sync by 1 for each version. This happens because the origin documents version number is not incremented until after the mongose pre save hook is run.

Incrementing the versionCopy's refVersion (if not zero) mimics the behaviour and caused the version number to correctly sync up.
