### PR TITLE
when cloning a user schema unique indexes should be ignored.

### DIFF
--- a/lib/clone-schema.js
+++ b/lib/clone-schema.js
@@ -15,5 +15,7 @@ module.exports = function (schema) {
         k[1] = args;
     });
 
+    newSchema._indexes = [];
+
     return newSchema;
 };


### PR DESCRIPTION
I'm not sure if the cleanest way would be just reseting the _indexes property, but it gets the job done. 
