### PR TITLE
Set versionModel._id to null when creating a copy of the shadow document

### DIFF
--- a/lib/strategies/collection.js
+++ b/lib/strategies/collection.js
@@ -26,7 +26,7 @@ module.exports = function(schema, options) {
         var versionedModel = new schema.statics.VersionedModel(this);
         versionedModel.refVersion = this._doc.__v;   // Saves current document version
         versionedModel.refId = this._id;        // Sets origins document id as a reference
-        delete versionedModel._id;
+        versionedModel._id = null;
 
         versionedModel.save(function(err) {
             if (err) {


### PR DESCRIPTION
Hi there,

I've updated the `versionModel._id = null` as discussed in https://github.com/saintedlama/mongoose-version/pull/7 and https://github.com/saintedlama/mongoose-version/issues/9

I've ran the provided test cases and performed tests to ensure a shadow document is created for each edit of the original document.

I've tested this in mongoose version 3.8.13

Can you please merge?
