### PR TITLE
Allow multiple db connections

### DIFF
--- a/lib/strategies/array.js
+++ b/lib/strategies/array.js
@@ -10,7 +10,7 @@ module.exports = function(schema, options) {
     var mongoose = options.mongoose;
     var Schema = mongoose.Schema;
     var ObjectId = Schema.Types.ObjectId;
-
+    var VersionedModel;
     var versionedSchema = new Schema({ refId : ObjectId, created : Date, modified : Date, versions : [clonedSchema] });
 
     if (options.documentProperty) {
@@ -45,9 +45,15 @@ module.exports = function(schema, options) {
 
     setSchemaOptions(versionedSchema, options);
 
-    // Add reference to model to original schema
-    var VersionedModel = mongoose.model(options.collection, versionedSchema);
-    schema.statics.VersionedModel = VersionedModel;
+    schema.statics.VersionedModel = {};
+
+    schema.on('init', function (Model) {
+        VersionedModel = Model.db.model(options.collection, versionedSchema);
+
+        schema.statics.VersionedModel = VersionedModel;
+        Model.VersionedModel = VersionedModel;
+    });
+
 
     schema.pre('save', function(next) {
         var self = this;

--- a/lib/strategies/collection.js
+++ b/lib/strategies/collection.js
@@ -17,7 +17,15 @@ module.exports = function(schema, options) {
     });
 
     // Add reference to model to original schema
-    schema.statics.VersionedModel = mongoose.model(options.collection, versionedSchema);
+    schema.statics.VersionedModel = {};
+
+    schema.on('init', function (Model) {
+        // Add reference to model to original schema
+        var VersionedModel = Model.db.model(options.collection, versionedSchema);
+
+        schema.statics.VersionedModel = VersionedModel;
+        Model.VersionedModel = VersionedModel;
+    });
 
     schema.pre('save', function (next) {
         if (!options.suppressVersionIncrement) {

--- a/test/fixtures/page.js
+++ b/test/fixtures/page.js
@@ -180,4 +180,6 @@ Page.index({
     }
 });
 
-module.exports = mongoose.model('schemausingtextsearchplugin', Page);
+module.exports = function(connection) {
+    return connection.model('schemausingtextsearchplugin', Page);
+};

--- a/test/mongotest.js
+++ b/test/mongotest.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 var mongoose = require('mongoose');
+var connection;
 
 function dropCollections(collections, index, cb) {
     if (typeof(index) == 'function') {
@@ -8,7 +9,7 @@ function dropCollections(collections, index, cb) {
     }
 
     if (index < collections.length) {
-        mongoose.connection.db.dropCollection(collections[index], function(err) {
+        connection.db.dropCollection(collections[index], function(err) {
             assert.ifError(err);
 
             dropCollections(collections, index + 1, cb);
@@ -25,10 +26,10 @@ module.exports = {
         return function(cb) {
             this.timeout(options.timeout);
 
-            mongoose.connect(connectionString, function(err) {
+            connection = mongoose.createConnection(connectionString, function(err) {
                 assert.ifError(err);
 
-                mongoose.connection.db.collections(function(err, collections) {
+                connection.db.collections(function(err, collections) {
                     assert.ifError(err);
 
                     var collectionsToDrop = collections

--- a/test/multiple-db-connections/issues.js
+++ b/test/multiple-db-connections/issues.js
@@ -2,14 +2,15 @@ var expect = require('chai').expect;
 var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 var mongotest = require('./mongotest');
-var version = require('../lib/version');
-var Page = require('./fixtures/page');
+var version = require('../../lib/version');
+var pageModel = require('../fixtures/page');
 
 describe('issues', function () {
     beforeEach(mongotest.prepareDb('mongodb://localhost/mongoose_version_issues_tests'));
     afterEach(mongotest.disconnect());
 
     it('should play nice with text search plugin', function (done) {
+        var Page = pageModel(mongotest.connection);
         var page = new Page({ title : 'Title', content : 'content', path : '/path' });
 
         page.save(function(err) {
@@ -32,7 +33,7 @@ describe('issues', function () {
             collection: 'userVersions'
         });
 
-        var User = mongoose.model('User', UserSchema);
+        var User = mongotest.connection.model('User', UserSchema);
 
         var user = new User({});
 
@@ -57,7 +58,7 @@ describe('issues', function () {
             collection: 'User_should_be_deleted_when_model_is_deleted_versions'
         });
 
-        var User = mongoose.model('User_should_be_deleted_when_model_is_deleted', UserSchema);
+        var User = mongotest.connection.model('User_should_be_deleted_when_model_is_deleted', UserSchema);
 
         var user = new User({});
 
@@ -87,7 +88,7 @@ describe('issues', function () {
             strategy: 'collection'
         });
 
-        var User = mongoose.model('User_should_be_deleted_when_model_is_in_collection_mode_deleted', UserSchema);
+        var User = mongotest.connection.model('User_should_be_deleted_when_model_is_in_collection_mode_deleted', UserSchema);
 
         var user = new User({});
 
@@ -116,7 +117,7 @@ describe('issues', function () {
             collection: 'User_should_not_save_a_versioned_model_when_field_is_excluded_versions'
         });
 
-        var User = mongoose.model('User_should_not_save_a_versioned_model_when_field_is_excluded', UserSchema);
+        var User = mongotest.connection.model('User_should_not_save_a_versioned_model_when_field_is_excluded', UserSchema);
 
         var user = new User({ });
 
@@ -170,7 +171,7 @@ describe('issues', function () {
             collection: 'User_should_ignore_indexes_in_cloned_model_versions'
         });
 
-        var User = mongoose.model('User_should_ignore_indexes_in_cloned_model', UserSchema);
+        var User = mongotest.connection.model('User_should_ignore_indexes_in_cloned_model', UserSchema);
 
         var user = new User({
             module: '538c5caa4f019dd4225fe4f7',
@@ -209,7 +210,7 @@ describe('issues', function () {
 
         schema.plugin(version, { strategy: 'collection', collection: 'PageVersionsCollectionIssue10' });
 
-        var model = mongoose.model('PageIssue10CollectionStrategy', schema);
+        var model = mongotest.connection.model('PageIssue10CollectionStrategy', schema);
 
         expect(model).to.exist;
     });
@@ -222,7 +223,7 @@ describe('issues', function () {
 
         schema.plugin(version, { strategy: 'array', collection: 'PageVersionsArrayIssue10' });
 
-        var model = mongoose.model('PageIssue10ArrayStrategy', schema);
+        var model = mongotest.connection.model('PageIssue10ArrayStrategy', schema);
 
         expect(model).to.exist;
     });

--- a/test/multiple-db-connections/mongotest.js
+++ b/test/multiple-db-connections/mongotest.js
@@ -1,6 +1,5 @@
 var assert = require('assert');
 var mongoose = require('mongoose');
-var connection;
 
 function dropCollections(collections, index, cb) {
     if (typeof(index) == 'function') {
@@ -9,7 +8,7 @@ function dropCollections(collections, index, cb) {
     }
 
     if (index < collections.length) {
-        connection.db.dropCollection(collections[index], function(err) {
+        module.exports.connection.db.dropCollection(collections[index], function(err) {
             assert.ifError(err);
 
             dropCollections(collections, index + 1, cb);
@@ -20,16 +19,17 @@ function dropCollections(collections, index, cb) {
 }
 
 module.exports = {
+    connection: {},
     prepareDb : function(connectionString, options) {
         options = options || {};
         options.timeout = options.timeout || 5000;
         return function(cb) {
             this.timeout(options.timeout);
 
-            connection = mongoose.createConnection(connectionString, function(err) {
+            module.exports.connection = mongoose.createConnection(connectionString, function(err) {
                 assert.ifError(err);
 
-                connection.db.collections(function(err, collections) {
+                module.exports.connection.db.collections(function(err, collections) {
                     assert.ifError(err);
 
                     var collectionsToDrop = collections

--- a/test/multiple-db-connections/version.js
+++ b/test/multiple-db-connections/version.js
@@ -2,7 +2,7 @@ var expect = require('chai').expect;
 var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 var mongotest = require('./mongotest');
-var version = require('../lib/version');
+var version = require('../../lib/version');
 
 describe('version', function() {
     beforeEach(mongotest.prepareDb('mongodb://localhost/mongoose_version_tests'));
@@ -13,7 +13,7 @@ describe('version', function() {
             var testSchema = new Schema();
             testSchema.plugin(version, { collection : 'should_expose_version_model_versions' });
             
-            var Test = mongoose.model('should_expose_version_model', testSchema);
+            var Test = mongotest.connection.model('should_expose_version_model', testSchema);
             
             expect(Test.VersionedModel).to.be.ok;
         });
@@ -23,7 +23,7 @@ describe('version', function() {
         var testSchema = new Schema({ name : String });
         testSchema.plugin(version, { collection : 'should_save_version_of_origin_model_versions' });
 
-        var Test = mongoose.model('should_save_version_of_origin_model', testSchema);
+        var Test = mongotest.connection.model('should_save_version_of_origin_model', testSchema);
 
         var test = new Test({ name: 'franz' });
         test.save(function(err) {
@@ -42,7 +42,7 @@ describe('version', function() {
         var testSchema = new Schema({ name : String });
         testSchema.plugin(version, { collection : 'should_save_version_of_origin_model_versions_twice' });
 
-        var Test = mongoose.model('should_save_version_of_origin_model_twice', testSchema);
+        var Test = mongotest.connection.model('should_save_version_of_origin_model_twice', testSchema);
 
         var test = new Test({ name: 'franz' });
         test.save(function(err) {
@@ -70,7 +70,7 @@ describe('version', function() {
         var testSchema = new Schema({ name : String });
         testSchema.plugin(version, 'should_accept_string');
 
-        var Test = mongoose.model('should_accept_string_origin_model', testSchema);
+        var Test = mongotest.connection.model('should_accept_string_origin_model', testSchema);
 
         expect(Test.VersionedModel.collection.name).to.equal('should_accept_string');
     });
@@ -87,7 +87,7 @@ describe('version', function() {
         var testSchema = new Schema({ name : String });
         testSchema.plugin(version, { strategy : 'array', collection : 'should_save_version_in_array' });
 
-        var Test = mongoose.model('should_save_version_in_array_origin_model', testSchema);
+        var Test = mongotest.connection.model('should_save_version_in_array_origin_model', testSchema);
 
         var test = new Test({ name: 'franz' });
         test.save(function(err) {
@@ -108,7 +108,7 @@ describe('version', function() {
         var testSchema = new Schema({ name : String, desc: String });
         testSchema.plugin(version, { strategy : 'collection', collection : 'should_save_version_in_collection' });
 
-        var Test = mongoose.model('should_save_version_in_collection_origin_model', testSchema);
+        var Test = mongotest.connection.model('should_save_version_in_collection_origin_model', testSchema);
 
         var test = new Test({ name: 'franz' });
         test.save(function(err) {
@@ -146,7 +146,7 @@ describe('version', function() {
         var testSchema = new Schema({ name : String });
         testSchema.plugin(version, { strategy : 'array', maxVersions : 1, collection : 'should_keep_only_max_versions' });
 
-        var Test = mongoose.model('should_keep_only_max_versions_origin_model', testSchema);
+        var Test = mongotest.connection.model('should_keep_only_max_versions_origin_model', testSchema);
 
         var test = new Test({ name: 'franz' });
         
@@ -177,7 +177,7 @@ describe('version', function() {
         var testSchema = new Schema({ name : String });
         testSchema.plugin(version, { strategy : 'array', documentProperty : 'name', collection : 'should_save_document_identifier_and_dates' });
 
-        var Test = mongoose.model('should_save_document_identifier_and_dates_model', testSchema);
+        var Test = mongotest.connection.model('should_save_document_identifier_and_dates_model', testSchema);
 
         var test = new Test({ name: 'franz' });
         test.save(function(err) {

--- a/test/single-db-connection/issues.js
+++ b/test/single-db-connection/issues.js
@@ -1,0 +1,230 @@
+var expect = require('chai').expect;
+var mongoose = require('mongoose');
+var Schema = mongoose.Schema;
+var mongotest = require('./mongotest');
+var version = require('../../lib/version');
+var pageModel = require('../fixtures/page');
+
+describe('issues', function () {
+    beforeEach(mongotest.prepareDb('mongodb://localhost/mongoose_version_issues_tests'));
+    afterEach(mongotest.disconnect());
+
+    it('should play nice with text search plugin', function (done) {
+        var Page = pageModel(mongoose.connection);
+        var page = new Page({ title : 'Title', content : 'content', path : '/path' });
+
+        page.save(function(err) {
+            expect(err).to.not.exist;
+
+            Page.VersionedModel.findOne({ refId : page._id }, function(err, versionedModel) {
+                expect(err).to.not.exist;
+                expect(versionedModel).to.be.ok;
+
+                done();
+            });
+        });
+    });
+
+    it('should allow to create an empty versioned model', function(done) {
+        var UserSchema = new Schema({});
+
+        UserSchema.plugin(version, {
+            logError: true,
+            collection: 'userVersions'
+        });
+
+        var User = mongoose.model('User', UserSchema);
+
+        var user = new User({});
+
+        user.save(function(err) {
+            expect(err).to.not.exist;
+
+            User.VersionedModel.find({}, function(err, models) {
+                expect(err).to.not.exist;
+                expect(models).to.be.not.empty;
+
+                done();
+            });
+        });
+    });
+
+    it('should delete versioned model when deleting the model', function(done) {
+        var UserSchema = new Schema({});
+
+        UserSchema.plugin(version, {
+            logError: true,
+            removeVersions: true,
+            collection: 'User_should_be_deleted_when_model_is_deleted_versions'
+        });
+
+        var User = mongoose.model('User_should_be_deleted_when_model_is_deleted', UserSchema);
+
+        var user = new User({});
+
+        user.save(function(err) {
+            expect(err).to.not.exist;
+
+            user.remove(function(err) {
+                expect(err).to.not.exist;
+
+                User.VersionedModel.find({}, function(err, models) {
+                    expect(err).to.not.exist;
+                    expect(models).to.be.empty;
+
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should delete versioned model when deleting the model in collection mode', function(done) {
+        var UserSchema = new Schema({});
+
+        UserSchema.plugin(version, {
+            logError: true,
+            removeVersions: true,
+            collection: 'User_should_be_deleted_when_model_is_deleted_in_collection_mode_versions',
+            strategy: 'collection'
+        });
+
+        var User = mongoose.model('User_should_be_deleted_when_model_is_in_collection_mode_deleted', UserSchema);
+
+        var user = new User({});
+
+        user.save(function(err) {
+            expect(err).to.not.exist;
+
+            user.remove(function(err) {
+                expect(err).to.not.exist;
+
+                User.VersionedModel.find({}, function(err, models) {
+                    expect(err).to.not.exist;
+                    expect(models).to.be.empty;
+
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should not save a versioned model when field is excluded', function(done) {
+        var UserSchema = new Schema({ excludeThisField : String, notExcludeThisField : String });
+
+        UserSchema.plugin(version, {
+            logError: true,
+            ignorePaths: 'excludeThisField',
+            collection: 'User_should_not_save_a_versioned_model_when_field_is_excluded_versions'
+        });
+
+        var User = mongoose.model('User_should_not_save_a_versioned_model_when_field_is_excluded', UserSchema);
+
+        var user = new User({ });
+
+        user.save(function(err) {
+            expect(err).to.not.exist;
+
+            user.excludeThisField = 'ThisShouldBeIgnoredFromVersioning';
+
+            user.save(function(err) {
+                expect(err).to.not.exist;
+
+                user.notExcludeThisField = 'ThisShouldNotBeIgnoredFromVersioning';
+
+                user.save(function(err) {
+                    expect(err).to.not.exist;
+
+                    User.VersionedModel.findOne({ refId : user._id }, function(err, model) {
+                        expect(err).to.not.exist;
+                        expect(model).to.be.not.empty;
+
+                        expect(model.versions.length).to.equal(2); // One update should be ignored
+
+                        done();
+                    });
+                });
+            });
+        });
+    });
+
+    it('should ignore unique indexes in cloned model', function(done){
+        var UserSchema = new Schema({
+            module: {
+                type: Schema.Types.ObjectId,
+                required: true
+            },
+            slug: {
+                type: String,
+                required: true
+            }
+        });
+
+        UserSchema.index({
+            module: 1,
+            slug: 1
+        }, {
+            unique: true
+        });
+
+        UserSchema.plugin(version, {
+            logError: true,
+            collection: 'User_should_ignore_indexes_in_cloned_model_versions'
+        });
+
+        var User = mongoose.model('User_should_ignore_indexes_in_cloned_model', UserSchema);
+
+        var user = new User({
+            module: '538c5caa4f019dd4225fe4f7',
+            slug: 'test-module'
+        });
+
+        user.save(function (err) {
+            expect(err).to.not.exist;
+            console.log('saved');
+
+            user.remove(function (err) {
+                expect(err).to.not.exist;
+                var user = new User({
+                    module: '538c5caa4f019dd4225fe4f7',
+                    slug: 'test-module'
+                });
+                user.save(function (err, user) {
+                    expect(err).to.not.exist;
+
+                    User.VersionedModel.findOne({ refId : user._id }, function(err, model) {
+                        expect(err).to.not.exist;
+                        expect(model).to.be.not.empty;
+
+                        done();
+                    });
+                });
+            });
+        });
+    });
+
+    it('should not break when using the plugin with collection strategy #10', function() {
+        var schema = new mongoose.Schema({
+          title: { type: String, required: true, trim: true },
+          content: { type: String, trim: true }
+        });
+
+        schema.plugin(version, { strategy: 'collection', collection: 'PageVersionsCollectionIssue10' });
+
+        var model = mongoose.model('PageIssue10CollectionStrategy', schema);
+
+        expect(model).to.exist;
+    });
+
+    it('should not break when using the plugin with array strategy #10', function() {
+        var schema = new mongoose.Schema({
+            title: { type: String, required: true, trim: true },
+            content: { type: String, trim: true }
+        });
+
+        schema.plugin(version, { strategy: 'array', collection: 'PageVersionsArrayIssue10' });
+
+        var model = mongoose.model('PageIssue10ArrayStrategy', schema);
+
+        expect(model).to.exist;
+    });
+});

--- a/test/single-db-connection/mongotest.js
+++ b/test/single-db-connection/mongotest.js
@@ -1,0 +1,49 @@
+var assert = require('assert');
+var mongoose = require('mongoose');
+
+function dropCollections(collections, index, cb) {
+    if (typeof(index) == 'function') {
+        cb = index;
+        index = 0;
+    }
+
+    if (index < collections.length) {
+        mongoose.connection.db.dropCollection(collections[index], function(err) {
+            assert.ifError(err);
+
+            dropCollections(collections, index + 1, cb);
+        });
+    } else {
+        cb();
+    }
+}
+
+module.exports = {
+    prepareDb : function(connectionString, options) {
+        options = options || {};
+        options.timeout = options.timeout || 5000;
+        return function(cb) {
+            this.timeout(options.timeout);
+
+            mongoose.connect(connectionString, function(err) {
+                assert.ifError(err);
+
+                mongoose.connection.db.collections(function(err, collections) {
+                    assert.ifError(err);
+
+                    var collectionsToDrop = collections
+                        .filter(function(col) { return col.collectionName.indexOf('system.') != 0; })
+                        .map(function(col) { return col.collectionName; });
+
+                    dropCollections(collectionsToDrop, 0, cb);
+                });
+            });
+        };
+    },
+
+    disconnect : function() {
+        return function(cb) {
+            mongoose.disconnect(cb);
+        }
+    }
+}

--- a/test/single-db-connection/version.js
+++ b/test/single-db-connection/version.js
@@ -1,0 +1,195 @@
+var expect = require('chai').expect;
+var mongoose = require('mongoose');
+var Schema = mongoose.Schema;
+var mongotest = require('./mongotest');
+var version = require('../../lib/version');
+
+describe('version', function() {
+    beforeEach(mongotest.prepareDb('mongodb://localhost/mongoose_version_tests'));
+    afterEach(mongotest.disconnect());
+
+    describe('#VersionModel', function() {
+        it('should expose a version model in the original schema', function() {
+            var testSchema = new Schema();
+            testSchema.plugin(version, { collection : 'should_expose_version_model_versions' });
+            
+            var Test = mongoose.model('should_expose_version_model', testSchema);
+            
+            expect(Test.VersionedModel).to.be.ok;
+        });
+    });
+    
+    it('should save a version model when saving origin model', function(done) {
+        var testSchema = new Schema({ name : String });
+        testSchema.plugin(version, { collection : 'should_save_version_of_origin_model_versions' });
+
+        var Test = mongoose.model('should_save_version_of_origin_model', testSchema);
+
+        var test = new Test({ name: 'franz' });
+        test.save(function(err) {
+            expect(err).to.not.exist;
+            
+            Test.VersionedModel.find({ refId : test._id, refVersion : test.__v }, function(err, versionedModel) {
+                expect(err).to.not.exist;
+                expect(versionedModel).to.be.ok;
+
+                done();
+            });
+        });
+    });
+
+    it('should save a version model when saving origin model twice', function(done) {
+        var testSchema = new Schema({ name : String });
+        testSchema.plugin(version, { collection : 'should_save_version_of_origin_model_versions_twice' });
+
+        var Test = mongoose.model('should_save_version_of_origin_model_twice', testSchema);
+
+        var test = new Test({ name: 'franz' });
+        test.save(function(err) {
+            expect(err).to.not.exist;
+
+            test.name = 'hugo';
+
+            test.save(function(err) {
+                expect(err).to.not.exist;
+
+                Test.VersionedModel.findOne({
+                    refId : test._id,
+                    versions : { $elemMatch : { refVersion : test.__v }}
+                }, function(err, versionedModel) {
+                    expect(err).to.not.exist;
+                    expect(versionedModel).to.be.ok;
+
+                    done();
+                });
+            });
+        });
+    });
+    
+    it('should accept options as string', function() {
+        var testSchema = new Schema({ name : String });
+        testSchema.plugin(version, 'should_accept_string');
+
+        var Test = mongoose.model('should_accept_string_origin_model', testSchema);
+
+        expect(Test.VersionedModel.collection.name).to.equal('should_accept_string');
+    });
+
+    it('should throw for unknown strategies', function() {
+        var testSchema = new Schema({ name : String });
+
+        expect(function() {
+            testSchema.plugin(version, { strategy: 'hugo' });
+        }).to.throw(Error);
+    });
+    
+    it('should save a version model in an array when using "array" strategy', function(done) {
+        var testSchema = new Schema({ name : String });
+        testSchema.plugin(version, { strategy : 'array', collection : 'should_save_version_in_array' });
+
+        var Test = mongoose.model('should_save_version_in_array_origin_model', testSchema);
+
+        var test = new Test({ name: 'franz' });
+        test.save(function(err) {
+            expect(err).to.not.exist;
+
+            Test.VersionedModel.findOne({ refId : test._id}, function(err, versionedModel) {
+                expect(err).to.not.exist;
+                expect(versionedModel).to.be.ok;
+
+                expect(versionedModel.versions.length).to.equal(1);
+
+                done();
+            });
+        });
+    });
+
+    it('should save a version model in a collection when using "collection" strategy', function(done) {
+        var testSchema = new Schema({ name : String, desc: String });
+        testSchema.plugin(version, { strategy : 'collection', collection : 'should_save_version_in_collection' });
+
+        var Test = mongoose.model('should_save_version_in_collection_origin_model', testSchema);
+
+        var test = new Test({ name: 'franz' });
+        test.save(function(err) {
+            expect(err).to.not.exist;
+
+            Test.VersionedModel.find({refId : test._id}, function(err, versionedModels) {
+                expect(err).to.not.exist;
+                expect(versionedModels).to.be.ok;
+
+                expect(versionedModels.length).to.equal(1);
+
+                test.desc = 'A lunar crater';
+                test.save(function(err) {
+                    expect(err).to.not.exist;
+
+                    Test.VersionedModel.find({refId : test._id}, function(err, versionedModels) {
+                        expect(err).to.not.exist;
+                        expect(versionedModels).to.be.ok;
+
+                        expect(versionedModels.length).to.equal(2);
+
+                        // One of them should have the new property
+                        expect(versionedModels.filter(function (m) {
+                            return m.desc == 'A lunar crater'
+                        }).length).to.equal(1);
+
+                        done();
+                    });
+                });
+            });
+        });
+    });
+
+    it('should keep maxVersions of version model in an array when using "array" strategy', function(done) {
+        var testSchema = new Schema({ name : String });
+        testSchema.plugin(version, { strategy : 'array', maxVersions : 1, collection : 'should_keep_only_max_versions' });
+
+        var Test = mongoose.model('should_keep_only_max_versions_origin_model', testSchema);
+
+        var test = new Test({ name: 'franz' });
+        
+        // Save one generates a version
+        test.save(function(err) {
+            expect(err).to.not.exist;
+
+            test.name = 'hugo';
+
+            // Save two generates a version
+            test.save(function(err) {
+                expect(err).to.not.exist;
+
+                Test.VersionedModel.findOne({ refId : test._id}, function(err, versionedModel) {
+                    expect(err).to.not.exist;
+                    expect(versionedModel).to.be.ok;
+
+                    // expected versions in array: 1
+                    expect(versionedModel.versions.length).to.equal(1);
+
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should save documentProperty as well as update and create dates', function(done) {
+        var testSchema = new Schema({ name : String });
+        testSchema.plugin(version, { strategy : 'array', documentProperty : 'name', collection : 'should_save_document_identifier_and_dates' });
+
+        var Test = mongoose.model('should_save_document_identifier_and_dates_model', testSchema);
+
+        var test = new Test({ name: 'franz' });
+        test.save(function(err) {
+            expect(err).to.not.exist;
+
+            Test.VersionedModel.findOne({ refId : test._id}, function(err, versionedModel) {
+                expect(versionedModel.created).to.be.ok;
+                expect(versionedModel.modified).to.be.ok;
+                expect(versionedModel.name).to.equal('franz');
+
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
As it is this module is relying in mongoose.connection being the default connection. We can listen to the 'init' event and use whatever connection was used by the Model where this plugin is running.