### PR TITLE
Fix for array strategy. Use mongoose instance passed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ model of page, for example for querying old versions of a document.
 ## Option keys and defaults
 * collection: name of the collection to persist versions to. The default is 'versions'. You should supply this option if you're using mongoose-version on more than one schema.
 * suppressVersionIncrement: mongoose-version will not increment the version of the saved model before saving the model by default. To turn on auto version increment set this option to false. Default: `true`
+* suppressRefIdIndex: mongoose-version will not index the refId field by default. To turn on indexing on refId set this option to false. Default: `true`
 * strategy: mongoose-version allows versioned document to be saved as multiple documents in a collection or in a single document in a version array. In case you want to save documents in an array specify `array` strategy, for storing versioned documents in multiple documents specify `collection` strategy. Default `array`.
 * maxVersions: Only valid for `array` strategy. Specifies how many historic versions of a document should be kept. Defaults to `Number.MAX_VALUE`.
 * mongoose: Pass a mongoose instance to work with

--- a/lib/strategies/array.js
+++ b/lib/strategies/array.js
@@ -4,10 +4,11 @@ var cloneSchema = require('../clone-schema');
 var setSchemaOptions = require('../set-schema-options');
 
 module.exports = function(schema, options) {
-    var clonedSchema = cloneSchema(schema);
+    var mongoose = options.mongoose;
+
+    var clonedSchema = cloneSchema(schema, mongoose);
     clonedSchema.add({ refVersion : Number });
 
-    var mongoose = options.mongoose;
     var Schema = mongoose.Schema;
     var ObjectId = Schema.Types.ObjectId;
 

--- a/lib/strategies/array.js
+++ b/lib/strategies/array.js
@@ -14,6 +14,10 @@ module.exports = function(schema, options) {
 
     var versionedSchema = new Schema({ refId : ObjectId, created : Date, modified : Date, versions : [clonedSchema] });
 
+    if (!options.suppressRefIdIndex) {
+        versionedSchema.index({ refId : 1 })
+    }
+
     if (options.documentProperty) {
         var documentPropertyField = {};
         documentPropertyField[options.documentProperty] = clonedSchema.path(options.documentProperty).options;

--- a/lib/strategies/collection.js
+++ b/lib/strategies/collection.js
@@ -23,7 +23,7 @@ module.exports = function(schema, options) {
             this.increment(); // Increment origins version    
         }
 
-        var clone = this._doc.toObject();
+        var clone = this.toObject();
 
         delete clone._id
         clone.refVersion = this._doc.__v;   // Saves current document version

--- a/lib/strategies/collection.js
+++ b/lib/strategies/collection.js
@@ -1,5 +1,4 @@
 var debug = require('debug')('mongoose:version');
-var xtend = require('xtend');
 
 var cloneSchema = require('../clone-schema');
 var setSchemaOptions = require('../set-schema-options');
@@ -24,7 +23,7 @@ module.exports = function(schema, options) {
             this.increment(); // Increment origins version    
         }
 
-        var clone = xtend(this._doc);
+        var clone = this._doc.toObject();
 
         delete clone._id
         clone.refVersion = this._doc.__v;   // Saves current document version

--- a/lib/version.js
+++ b/lib/version.js
@@ -13,6 +13,7 @@ module.exports = function(schema, options) {
     options.strategy = options.strategy || 'array';
     options.maxVersions = options.maxVersions || Number.MAX_VALUE;
     options.suppressVersionIncrement = options.suppressVersionIncrement !== false;
+    options.suppressRefIdIndex = options.suppressRefIdIndex !== false;
     options.mongoose = options.mongoose || require('mongoose');
     options.removeVersions = !!options.removeVersions;
     options.ignorePaths = options.ignorePaths||[];

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   ],
   "dependencies": {
     "debug": "~0.8.1",
-    "mongoose": "~3.8.12",
-    "xtend": "^4.0.0"
+    "mongoose": "~3.8.12"
   },
   "devDependencies": {
     "chai": "~1.9.1",


### PR DESCRIPTION
This should fix situation using another major version of mongoose and chose array strategy

And I know nothing about npm, could you publish the latest version (at least after the clone-schema change) to npm?