### PR TITLE
Make the refId type configurable. Fixes #19.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ model of page, for example for querying old versions of a document.
 * mongoose: Pass a mongoose instance to work with
 * removeVersions: Removes versions when origin document is removed. Defaults to `false`
 * ignorePaths: Defines an array of document field names that do not trigger a new version to be created when this field was changed. Only working with array strategy (default strategy). Defaults to `[]`.
+* refIdType: The type of the `_id` field used in your document. Will be used to set the type of the refId. Defaults to `ObjectId`.
 * Options are passed to a newly created mongoose schemas as settings, so you may use any [option supported by mongoose](http://mongoosejs.com/docs/guide.html#options)
 
 In case you only want to specify the collection name, you can pass a string instance to options that is taken as collection name. Options may be passed as follows:

--- a/lib/clone-schema.js
+++ b/lib/clone-schema.js
@@ -6,6 +6,10 @@ module.exports = function(schema, mongoose) {
   var clonedSchema = new mongoose.Schema();
 
   schema.eachPath(function(key, path) {
+    if (key === "_id") {
+      return;
+    }
+
     var clonedPath = {};
 
     clonedPath[key] = path.options;

--- a/lib/strategies/array.js
+++ b/lib/strategies/array.js
@@ -11,8 +11,9 @@ module.exports = function(schema, options) {
 
   var Schema = mongoose.Schema;
   var ObjectId = Schema.Types.ObjectId;
+  var refIdType = options.refIdType || ObjectId;
 
-  var versionedSchema = new Schema({ refId: ObjectId, created: Date, modified: Date, versions: [clonedSchema] });
+  var versionedSchema = new Schema({ refId: refIdType, created: Date, modified: Date, versions: [clonedSchema] });
 
   if (!options.suppressRefIdIndex) {
     versionedSchema.index({ refId: 1 })

--- a/lib/strategies/collection.js
+++ b/lib/strategies/collection.js
@@ -7,11 +7,12 @@ module.exports = function(schema, options) {
   var versionedSchema = cloneSchema(schema, options.mongoose);
   var mongoose = options.mongoose;
   var ObjectId = mongoose.Schema.Types.ObjectId;
+  var refIdType = options.refIdType || ObjectId;
 
   setSchemaOptions(versionedSchema, options);
 
   versionedSchema.add({
-    refId: ObjectId,
+    refId: refIdType,
     refVersion: Number
   });
 


### PR DESCRIPTION
It was assumed that the refId would always be an `ObjectId`, however this isn't necessarily the case. This diff adds a new configuration option which allows the type of the refId to be changed to something else (e.g. `String`).