### PR TITLE
Check that 'unique' exists. Fixes #26

### DIFF
--- a/lib/clone-schema.js
+++ b/lib/clone-schema.js
@@ -13,7 +13,7 @@ module.exports = function(schema, mongoose) {
     var clonedPath = {};
 
     clonedPath[key] = path.options;
-    clonedPath[key].unique = false;
+    delete clonedPath[key].unique;
 
     clonedSchema.add(clonedPath);
   });


### PR DESCRIPTION
Fix setting `unique = false` on fields will create (non-unique) single field index on all fields