### PR TITLE
Adds custom schema paths for e.g. time tracking of versions and fixes multiple validation issues

### DIFF
--- a/lib/clone-schema.js
+++ b/lib/clone-schema.js
@@ -19,6 +19,7 @@ module.exports = function(schema, mongoose) {
     clonedSchema.add(clonedPath);
   });
 
-  clonedSchema.add({ lastmodif_version: { type: Date, default: new Date() }})
+  var modpath = "__v_modifiedDate"
+  if(!clonedSchema.path(modpath)) clonedSchema.add({ modpath: { type: Date, required: true }})
   return clonedSchema;
 };

--- a/lib/clone-schema.js
+++ b/lib/clone-schema.js
@@ -20,6 +20,6 @@ module.exports = function(schema, mongoose) {
   });
 
   var modpath = "__v_modifiedDate"
-  if(!clonedSchema.path(modpath)) clonedSchema.add({ modpath: { type: Date, required: true }})
+  if(!clonedSchema.path(modpath)) clonedSchema.add({ modpath: { type: Date }})
   return clonedSchema;
 };

--- a/lib/clone-schema.js
+++ b/lib/clone-schema.js
@@ -19,7 +19,6 @@ module.exports = function(schema, mongoose) {
     clonedSchema.add(clonedPath);
   });
 
-  var modpath = "__v_modifiedDate"
-  if(!clonedSchema.path(modpath)) clonedSchema.add({ modpath: { type: Date }})
+  if(!clonedSchema.path("modo")) clonedSchema.add({ modo: { type: Date }})
   return clonedSchema;
 };

--- a/lib/clone-schema.js
+++ b/lib/clone-schema.js
@@ -14,6 +14,7 @@ module.exports = function(schema, mongoose) {
 
     clonedPath[key] = path.options;
     delete clonedPath[key].unique;
+    delete clonedPath[key].validate;
 
     clonedSchema.add(clonedPath);
   });

--- a/lib/clone-schema.js
+++ b/lib/clone-schema.js
@@ -19,5 +19,6 @@ module.exports = function(schema, mongoose) {
     clonedSchema.add(clonedPath);
   });
 
+  clonedSchema.add({ lastmodif_version: { type: Date, detault: new Date() }})
   return clonedSchema;
 };

--- a/lib/clone-schema.js
+++ b/lib/clone-schema.js
@@ -19,6 +19,6 @@ module.exports = function(schema, mongoose) {
     clonedSchema.add(clonedPath);
   });
 
-  clonedSchema.add({ lastmodif_version: { type: Date, detault: new Date() }})
+  clonedSchema.add({ lastmodif_version: { type: Date, default: new Date() }})
   return clonedSchema;
 };

--- a/lib/clone-schema.js
+++ b/lib/clone-schema.js
@@ -19,6 +19,6 @@ module.exports = function(schema, mongoose) {
     clonedSchema.add(clonedPath);
   });
 
-  if(!clonedSchema.path("modo")) clonedSchema.add({ modo: { type: Date }})
+  if(!clonedSchema.path("__version_modifiedDate")) clonedSchema.add({ __version_modifiedDate: { type: Date }})
   return clonedSchema;
 };

--- a/lib/strategies/array.js
+++ b/lib/strategies/array.js
@@ -30,7 +30,7 @@ module.exports = function(schema, options) {
     var modifDate = new Date()
     // Set modif date on last document in versions array
     var lastDoc = this.versions[this.versions.length-1]
-    if(lastDoc) lastDoc["__v_modifiedDate"]
+    if(lastDoc) lastDoc["__v_modifiedDate"] = modifDate
     if (!this.created) {
       this.created = modifDate;
     }

--- a/lib/strategies/array.js
+++ b/lib/strategies/array.js
@@ -17,92 +17,110 @@ module.exports = function(schema, options) {
 
   if (options.addPath) {
     for (var key in options.addPath) {
-      if(!clonedSchema.path(key)) {
-        clonedSchema.add({ [key]:  options.addPath[key] })
+      if (!clonedSchema.path(key)) {
+        clonedSchema.add({ [key]: options.addPath[key] })
       }
-  }
-  
-  if (!options.suppressRefIdIndex) {
-    versionedSchema.index({ refId: 1 })
-  }
-
-  if (options.documentProperty) {
-    var documentPropertyField = {};
-    documentPropertyField[options.documentProperty] = clonedSchema.path(options.documentProperty).options;
-
-    versionedSchema.add(documentPropertyField);
-  }
-
-  versionedSchema.pre('save', function(next) {
-    if (!this.created) {
-      this.created = new Date();
     }
 
-    this.modified = new Date();
-
-    next();
-  });
-
-  versionedSchema.statics.latest = function(count, cb) {
-    if (typeof(count) == 'function') {
-      cb = count;
-      count = 10;
+    if (!options.suppressRefIdIndex) {
+      versionedSchema.index({ refId: 1 })
     }
 
-    return this
-      .find({})
-      .limit(count)
-      .sort('-created')
-      .exec(cb);
-  };
+    if (options.documentProperty) {
+      var documentPropertyField = {};
+      documentPropertyField[options.documentProperty] = clonedSchema.path(options.documentProperty).options;
 
-  setSchemaOptions(versionedSchema, options);
-
-  // Add reference to model to original schema
-  var VersionedModel = mongoose.model(options.collection, versionedSchema);
-  schema.statics.VersionedModel = VersionedModel;
-
-  schema.pre('save', function(next) {
-    var self = this;
-
-    if (!options.suppressVersionIncrement) {
-      this.increment(); // Increment origins version
+      versionedSchema.add(documentPropertyField);
     }
 
-    var modifiedPaths = this.modifiedPaths();
+    versionedSchema.pre('save', function(next) {
+      if (!this.created) {
+        this.created = new Date();
+      }
 
-    if (modifiedPaths.length) {
-      var onlyIgnoredPathModified = modifiedPaths.every(function(path) {
-        return options.ignorePaths.indexOf(path) >= 0;
+      this.modified = new Date();
+
+      next();
+    });
+
+    versionedSchema.statics.latest = function(count, cb) {
+      if (typeof (count) == 'function') {
+        cb = count;
+        count = 10;
+      }
+
+      return this
+        .find({})
+        .limit(count)
+        .sort('-created')
+        .exec(cb);
+    };
+
+    setSchemaOptions(versionedSchema, options);
+
+    // Add reference to model to original schema
+    var VersionedModel = mongoose.model(options.collection, versionedSchema);
+    schema.statics.VersionedModel = VersionedModel;
+
+    schema.pre('save', function(next) {
+      var self = this;
+
+      if (!options.suppressVersionIncrement) {
+        this.increment(); // Increment origins version
+      }
+
+      var modifiedPaths = this.modifiedPaths();
+
+      if (modifiedPaths.length) {
+        var onlyIgnoredPathModified = modifiedPaths.every(function(path) {
+          return options.ignorePaths.indexOf(path) >= 0;
+        });
+
+        if (onlyIgnoredPathModified) {
+          return next();
+        }
+      }
+
+      VersionedModel.findOne({ refId: this._id }, function(err, versionedModel) {
+        if (!versionedModel) {
+          versionedModel = new VersionedModel({ refId: self._id, versions: [] });
+        }
+
+        // Set a document identifier in case it was specified in options
+        if (options.documentProperty) {
+          versionedModel[options.documentProperty] = self[options.documentProperty];
+        }
+
+        var versionCopy = self.toObject();
+
+        versionCopy.refVersion = self._doc.__v + 1 || 0;
+        versionCopy._id = undefined;
+
+        versionedModel.versions.push(versionCopy);
+
+        if (versionedModel.versions.length > options.maxVersions) {
+          versionedModel.versions.shift();
+        }
+
+        versionedModel.save(function(err) {
+          if (err) {
+            debug(err);
+          } else {
+            debug('Removed versioned model from mongodb');
+          }
+
+          next();
+        });
       });
+    });
 
-      if (onlyIgnoredPathModified) {
+
+    schema.pre('remove', function(next) {
+      if (!options.removeVersions) {
         return next();
       }
-    }
 
-    VersionedModel.findOne({ refId: this._id }, function(err, versionedModel) {
-      if (!versionedModel) {
-        versionedModel = new VersionedModel({ refId: self._id, versions: [] });
-      }
-
-      // Set a document identifier in case it was specified in options
-      if (options.documentProperty) {
-        versionedModel[options.documentProperty] = self[options.documentProperty];
-      }
-
-      var versionCopy = self.toObject();
-
-      versionCopy.refVersion = self._doc.__v + 1 || 0;
-      versionCopy._id = undefined;
-
-      versionedModel.versions.push(versionCopy);
-
-      if (versionedModel.versions.length > options.maxVersions) {
-        versionedModel.versions.shift();
-      }
-
-      versionedModel.save(function(err) {
+      VersionedModel.remove({ refId: this._id }, function(err) {
         if (err) {
           debug(err);
         } else {
@@ -112,22 +130,4 @@ module.exports = function(schema, options) {
         next();
       });
     });
-  });
-
-
-  schema.pre('remove', function(next) {
-    if (!options.removeVersions) {
-      return next();
-    }
-
-    VersionedModel.remove({ refId: this._id }, function(err) {
-      if (err) {
-        debug(err);
-      } else {
-        debug('Removed versioned model from mongodb');
-      }
-
-      next();
-    });
-  });
-};
+  };

--- a/lib/strategies/array.js
+++ b/lib/strategies/array.js
@@ -27,7 +27,9 @@ module.exports = function(schema, options) {
   }
 
   versionedSchema.pre('save', function(next) {
-    console.log(this)
+    // Set modif date on last document in versions array
+    var lastDoc = this.versions.(this.versions.length-1)
+    console.log(lastDoc)
 
     if (!this.created) {
       this.created = new Date();

--- a/lib/strategies/array.js
+++ b/lib/strategies/array.js
@@ -35,6 +35,8 @@ module.exports = function(schema, options) {
   }
 
   versionedSchema.pre('save', function(next) {
+    console.log(this)
+
     if (!this.created) {
       this.created = new Date();
     }

--- a/lib/strategies/array.js
+++ b/lib/strategies/array.js
@@ -28,6 +28,7 @@ module.exports = function(schema, options) {
 
   versionedSchema.pre('save', function(next) {
     var modifDate = new Date()
+
     // Set modif date on last document in versions array
     var lastDoc = this.versions[this.versions.length-1]
     if(lastDoc) lastDoc.__version_modifiedDate = modifDate

--- a/lib/strategies/array.js
+++ b/lib/strategies/array.js
@@ -15,6 +15,13 @@ module.exports = function(schema, options) {
 
   var versionedSchema = new Schema({ refId: refIdType, created: Date, modified: Date, versions: [clonedSchema] });
 
+  if (options.addPath) {
+    for (var key in options.addPath) {
+      if(!clonedSchema.path(key)) {
+        clonedSchema.add({ [key]:  options.addPath[key] })
+      }
+  }
+  
   if (!options.suppressRefIdIndex) {
     versionedSchema.index({ refId: 1 })
   }

--- a/lib/strategies/array.js
+++ b/lib/strategies/array.js
@@ -30,9 +30,7 @@ module.exports = function(schema, options) {
     var modifDate = new Date()
     // Set modif date on last document in versions array
     var lastDoc = this.versions[this.versions.length-1]
-    if(lastDoc) lastDoc.modo = modifDate
-    console.log(this.versions)
-    console.log(lastDoc)
+    if(lastDoc) lastDoc.__version_modifiedDate = modifDate
 
     if (!this.created) {
       this.created = modifDate;

--- a/lib/strategies/array.js
+++ b/lib/strategies/array.js
@@ -27,15 +27,14 @@ module.exports = function(schema, options) {
   }
 
   versionedSchema.pre('save', function(next) {
+    var modifDate = new Date()
     // Set modif date on last document in versions array
     var lastDoc = this.versions[this.versions.length-1]
-    console.log(lastDoc)
-
+    if(lastDoc) lastDoc["__v_modifiedDate"]
     if (!this.created) {
-      this.created = new Date();
+      this.created = modifDate;
     }
-
-    this.modified = new Date();
+    this.modified = modifDate;
 
     next();
   });

--- a/lib/strategies/array.js
+++ b/lib/strategies/array.js
@@ -28,7 +28,7 @@ module.exports = function(schema, options) {
 
   versionedSchema.pre('save', function(next) {
     // Set modif date on last document in versions array
-    var lastDoc = this.versions.(this.versions.length-1)
+    var lastDoc = this.versions[this.versions.length-1]
     console.log(lastDoc)
 
     if (!this.created) {

--- a/lib/strategies/array.js
+++ b/lib/strategies/array.js
@@ -31,6 +31,8 @@ module.exports = function(schema, options) {
     // Set modif date on last document in versions array
     var lastDoc = this.versions[this.versions.length-1]
     if(lastDoc) lastDoc["__v_modifiedDate"] = modifDate
+    console.log(this.versions)
+    console.log(lastDoc)
     if (!this.created) {
       this.created = modifDate;
     }

--- a/lib/strategies/array.js
+++ b/lib/strategies/array.js
@@ -30,12 +30,14 @@ module.exports = function(schema, options) {
     var modifDate = new Date()
     // Set modif date on last document in versions array
     var lastDoc = this.versions[this.versions.length-1]
-    if(lastDoc) lastDoc["__v_modifiedDate"] = modifDate
+    if(lastDoc) lastDoc.modo = modifDate
     console.log(this.versions)
     console.log(lastDoc)
+
     if (!this.created) {
       this.created = modifDate;
     }
+    
     this.modified = modifDate;
 
     next();

--- a/lib/strategies/array.js
+++ b/lib/strategies/array.js
@@ -21,106 +21,89 @@ module.exports = function(schema, options) {
         clonedSchema.add({ [key]: options.addPath[key] })
       }
     }
+  }
 
-    if (!options.suppressRefIdIndex) {
-      versionedSchema.index({ refId: 1 })
+  if (!options.suppressRefIdIndex) {
+    versionedSchema.index({ refId: 1 })
+  }
+
+  if (options.documentProperty) {
+    var documentPropertyField = {};
+    documentPropertyField[options.documentProperty] = clonedSchema.path(options.documentProperty).options;
+
+    versionedSchema.add(documentPropertyField);
+  }
+
+  versionedSchema.pre('save', function(next) {
+    if (!this.created) {
+      this.created = new Date();
     }
 
-    if (options.documentProperty) {
-      var documentPropertyField = {};
-      documentPropertyField[options.documentProperty] = clonedSchema.path(options.documentProperty).options;
+    this.modified = new Date();
 
-      versionedSchema.add(documentPropertyField);
+    next();
+  });
+
+  versionedSchema.statics.latest = function(count, cb) {
+    if (typeof (count) == 'function') {
+      cb = count;
+      count = 10;
     }
 
-    versionedSchema.pre('save', function(next) {
-      if (!this.created) {
-        this.created = new Date();
-      }
+    return this
+      .find({})
+      .limit(count)
+      .sort('-created')
+      .exec(cb);
+  };
 
-      this.modified = new Date();
+  setSchemaOptions(versionedSchema, options);
 
-      next();
-    });
+  // Add reference to model to original schema
+  var VersionedModel = mongoose.model(options.collection, versionedSchema);
+  schema.statics.VersionedModel = VersionedModel;
 
-    versionedSchema.statics.latest = function(count, cb) {
-      if (typeof (count) == 'function') {
-        cb = count;
-        count = 10;
-      }
+  schema.pre('save', function(next) {
+    var self = this;
 
-      return this
-        .find({})
-        .limit(count)
-        .sort('-created')
-        .exec(cb);
-    };
+    if (!options.suppressVersionIncrement) {
+      this.increment(); // Increment origins version
+    }
 
-    setSchemaOptions(versionedSchema, options);
+    var modifiedPaths = this.modifiedPaths();
 
-    // Add reference to model to original schema
-    var VersionedModel = mongoose.model(options.collection, versionedSchema);
-    schema.statics.VersionedModel = VersionedModel;
-
-    schema.pre('save', function(next) {
-      var self = this;
-
-      if (!options.suppressVersionIncrement) {
-        this.increment(); // Increment origins version
-      }
-
-      var modifiedPaths = this.modifiedPaths();
-
-      if (modifiedPaths.length) {
-        var onlyIgnoredPathModified = modifiedPaths.every(function(path) {
-          return options.ignorePaths.indexOf(path) >= 0;
-        });
-
-        if (onlyIgnoredPathModified) {
-          return next();
-        }
-      }
-
-      VersionedModel.findOne({ refId: this._id }, function(err, versionedModel) {
-        if (!versionedModel) {
-          versionedModel = new VersionedModel({ refId: self._id, versions: [] });
-        }
-
-        // Set a document identifier in case it was specified in options
-        if (options.documentProperty) {
-          versionedModel[options.documentProperty] = self[options.documentProperty];
-        }
-
-        var versionCopy = self.toObject();
-
-        versionCopy.refVersion = self._doc.__v + 1 || 0;
-        versionCopy._id = undefined;
-
-        versionedModel.versions.push(versionCopy);
-
-        if (versionedModel.versions.length > options.maxVersions) {
-          versionedModel.versions.shift();
-        }
-
-        versionedModel.save(function(err) {
-          if (err) {
-            debug(err);
-          } else {
-            debug('Removed versioned model from mongodb');
-          }
-
-          next();
-        });
+    if (modifiedPaths.length) {
+      var onlyIgnoredPathModified = modifiedPaths.every(function(path) {
+        return options.ignorePaths.indexOf(path) >= 0;
       });
-    });
 
-
-    schema.pre('remove', function(next) {
-      if (!options.removeVersions) {
+      if (onlyIgnoredPathModified) {
         return next();
       }
+    }
 
-      VersionedModel.remove({ refId: this._id }, function(err) {
+    VersionedModel.findOne({ refId: this._id }, function(err, versionedModel) {
+      if (!versionedModel) {
+        versionedModel = new VersionedModel({ refId: self._id, versions: [] });
+      }
+
+      // Set a document identifier in case it was specified in options
+      if (options.documentProperty) {
+        versionedModel[options.documentProperty] = self[options.documentProperty];
+      }
+
+      var versionCopy = self.toObject();
+
+      versionCopy.refVersion = self._doc.__v + 1 || 0;
+      versionCopy._id = undefined;
+
+      versionedModel.versions.push(versionCopy);
+
+      if (versionedModel.versions.length > options.maxVersions) {
+        versionedModel.versions.shift();
+      }
+
+      versionedModel.save(function(err) {
         if (err) {
           debug(err);
         } else {
@@ -130,4 +113,22 @@ module.exports = function(schema, options) {
         next();
       });
     });
-  };
+  });
+
+
+  schema.pre('remove', function(next) {
+    if (!options.removeVersions) {
+      return next();
+    }
+
+    VersionedModel.remove({ refId: this._id }, function(err) {
+      if (err) {
+        debug(err);
+      } else {
+        debug('Removed versioned model from mongodb');
+      }
+
+      next();
+    });
+  });
+};

--- a/lib/strategies/array.js
+++ b/lib/strategies/array.js
@@ -15,14 +15,6 @@ module.exports = function(schema, options) {
 
   var versionedSchema = new Schema({ refId: refIdType, created: Date, modified: Date, versions: [clonedSchema] });
 
-  if (options.addPath) {
-    for (var key in options.addPath) {
-      if (!clonedSchema.path(key)) {
-        clonedSchema.add({ [key]: options.addPath[key] })
-      }
-    }
-  }
-
   if (!options.suppressRefIdIndex) {
     versionedSchema.index({ refId: 1 })
   }


### PR DESCRIPTION
Re to the following issues I created this fix and pull request:
https://github.com/saintedlama/mongoose-version/issues/30
https://github.com/saintedlama/mongoose-version/issues/29

User is now able to add a custom path to e.g. track creation time of each version document like this:

```
MyLovelySchema.plugin(mongooseVersion, { 
  collection: collection + "__versions", 
  addPath: { version_modifiedDate: { type: Date, default: new Date } } 
})
```
Please consider merging my changes.